### PR TITLE
Avoid ConcurrentModificationException in CloudSim.runClockTick()

### DIFF
--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -509,8 +509,8 @@ public class CloudSim {
 		
 		int entities_size = entities.size();
 
-		for (SimEntity entity : entities) {
-			ent = entity;
+		for (int i = 0; i < entities_size; i++) {
+			ent = entities.get(i);
 			if (ent.getState() == SimEntity.RUNNABLE) {
 				ent.run();
 			}

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -507,9 +507,7 @@ public class CloudSim {
 		SimEntity ent;
 		boolean queue_empty;
 		
-		int entities_size = entities.size();
-
-		for (int i = 0; i < entities_size; i++) {
+		for (int i = 0; i < entities.size(); i++) {
 			ent = entities.get(i);
 			if (ent.getState() == SimEntity.RUNNABLE) {
 				ent.run();


### PR DESCRIPTION
Fixes: https://github.com/Cloudslab/cloudsim/issues/187

ConcurrentModificationException can occur when SimEntity changes it's own state during `run()` depending upon implementation in between the Simulation clock ticks. This causes to break the simulator run similar to what happens today in CloudSimExample8. Although, this change fixes the said example it now allows users to write their SimEntity implementation in a way that during `processEvent` / `run` etc. during the lifecycle of the entity processing it can **change it's own state, i.e. change the values of it's linked variables**; from a design perspective of the simulator this may/may not be allowed. 

In case of CloudSimExample8, the GlobalBroker implementation changes it's state during the course of it's run which today causes the exception to occur so alternative pathway is that we might need to fix the Broker implementation. 