### PR TITLE
Update README.md Maven build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Either clone the repository or download a [release](https://github.com/Cloudslab
 2) Install Maven as shown on the [official website](https://maven.apache.org/install.html)
 4) Compile and Run tests using the command prompt:
   ```prompt
-  mvn build
-  mvn test
+  mvn clean package
   ```
 5) Run an example (e.g., CloudSimExample1) in cloudsim-examples using the command prompt:
 ```prompt
@@ -61,8 +60,7 @@ mvn exec:java -pl modules/cloudsim-examples/ -Dexec.mainClass=org.cloudbus.cloud
   3) Install Maven as shown on the [Official Website](https://maven.apache.org/install.html)
   4) Compile and run tests using the terminal:
   ```bash
-  mvn build
-  mvn test
+  mvn clean package
   ```
   5) Run an example (e.g., CloudSimExample1) in cloudsim-examples using the terminal:
   ```bash


### PR DESCRIPTION
The original `README.md` instructed the use of `mvn build`, an invalid command, to build the project.

The `mvn clean package` command starts the full build cycle including compiling, testing and packaging.

My Maven version:
```
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /usr/share/java/maven
Java version: 21.0.5, vendor: Arch Linux, runtime: /usr/lib/jvm/java-21-openjdk
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.12.8-arch1-1", arch: "amd64", family: "unix"
```