### PR TITLE
core package unit tests and bug fixes

### DIFF
--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -8,19 +8,12 @@
 
 package org.cloudbus.cloudsim.core;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import org.cloudbus.cloudsim.Log;
 import org.cloudbus.cloudsim.core.predicates.Predicate;
 import org.cloudbus.cloudsim.core.predicates.PredicateAny;
 import org.cloudbus.cloudsim.core.predicates.PredicateNone;
+
+import java.util.*;
 
 /**
  *
@@ -35,6 +28,11 @@ import org.cloudbus.cloudsim.core.predicates.PredicateNone;
  */
 public class CloudSim {
 
+	/**
+	 * The resume event, used to wake up the simulation thread.
+	 */
+	private static final Object pauseObj = new Object();
+
 	/** The Constant CLOUDSIM_VERSION_STRING. */
 	private static final String CLOUDSIM_VERSION_STRING = "7.0";
 
@@ -48,7 +46,7 @@ public class CloudSim {
 	private static CloudInformationService cis = null;
 
 	/** The Constant NOT_FOUND. */
-	private static final int NOT_FOUND = -1;
+	public static final int NOT_FOUND = -1;
 
 	/** The trace flag. */
 	private static boolean traceFlag = false;
@@ -258,13 +256,7 @@ public class CloudSim {
 	 * @post $none
 	 */
 	public static Calendar getSimulationCalendar() {
-		// make a new copy
-		Calendar clone = calendar;
-		if (calendar != null) {
-			clone = (Calendar) calendar.clone();
-		}
-
-		return clone;
+		return calendar != null ? (Calendar) calendar.clone() : null;
 	}
 
 	/**
@@ -339,7 +331,11 @@ public class CloudSim {
 		future = new EventQueue();
 		waitPredicates = new HashMap<>();
 		clock = 0;
+		abruptTerminate = false;
+		terminateAt = -1;
 		running = false;
+		pauseAt = -1;
+		paused = false;
 	}
 
 	// The two standard predicates
@@ -444,8 +440,7 @@ public class CloudSim {
 	public static List<SimEntity> getEntityList() {
 		// create a new list to prevent the user from changing
 		// the list of entities used by Simulation
-		List<SimEntity> list = new LinkedList<>(entities);
-		return list;
+		return new LinkedList<>(entities);
 	}
 
 	// Public update methods
@@ -548,7 +543,7 @@ public class CloudSim {
 			throw new IllegalArgumentException("Send delay can't be negative.");
 		}
 		if(delay >= Double.MAX_VALUE) {
-			throw new RuntimeException("Send delay can't be infinite.");
+			throw new IllegalArgumentException("Send delay can't be infinite.");
 		}
 
 		SimEvent e = new SimEvent(SimEvent.SEND, clock + delay, srcId, dstId, tag, data);
@@ -562,11 +557,13 @@ public class CloudSim {
 	 * @param dstId the dest
 	 * @param delay the delay
 	 * @param tag the tag
-	 * @param data the data
 	 */
 	public static void sendFirst(int srcId, int dstId, double delay, CloudSimTags tag, Object data) {
 		if (delay < 0) {
 			throw new IllegalArgumentException("Send delay can't be negative.");
+		}
+		if (delay >= Double.MAX_VALUE) {
+			throw new IllegalArgumentException("Send delay can't be infinite.");
 		}
 
 		SimEvent e = new SimEvent(SimEvent.SEND, clock + delay, srcId, dstId, tag, data);
@@ -703,8 +700,9 @@ public class CloudSim {
 	 * @return true, if successful otherwise.
 	 */
 	public static boolean pauseSimulation() {
-		paused = true;
-		return paused;
+		synchronized (pauseObj) {
+			return paused = true;
+		}
 	}
 
 	/**
@@ -714,27 +712,34 @@ public class CloudSim {
 	 * @return true, if successful otherwise.
 	 */
 	public static boolean pauseSimulation(long time) {
-		if (time <= clock) {
-			return false;
-		} else {
-			pauseAt = time;
+		synchronized (pauseObj) {
+			if (time <= clock) {
+				return false;
+			} else {
+				pauseAt = time;
+			}
+			return true;
 		}
-		return true;
 	}
 
 	/**
 	 * This method is called if one wants to resume the simulation that has previously been paused.
-	 * 
-	 * @return if the simulation has been restarted or or otherwise.
+	 *
+	 * @return if the simulation has been restarted or otherwise.
 	 */
 	public static boolean resumeSimulation() {
-		paused = false;
+		synchronized (pauseObj) {
+			var wasPaused = paused;
+			paused = false;
 
-		if (pauseAt <= clock) {
-			pauseAt = -1;
+			if (pauseAt <= clock) {
+				pauseAt = -1;
+			}
+
+			pauseObj.notify();
+
+			return !wasPaused;
 		}
-
-		return !paused;
 	}
 
 	/**
@@ -766,11 +771,15 @@ public class CloudSim {
 				clock = pauseAt;
 			}
 
-			while (paused) {
-				try {
-					Thread.sleep(100);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
+			// Outside the synchronized block to avoid slowing down the main loop.
+			if (paused) {
+				synchronized (pauseObj) {
+					try {
+						while (paused)
+							pauseObj.wait();
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
 				}
 			}
 		}

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/EventQueue.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/EventQueue.java
@@ -23,6 +23,7 @@ import java.util.PriorityQueue;
 public class EventQueue extends PriorityQueue<SimEvent> {
 	/** A incremental number used for event attribute */
 	private long serial = 0;
+	private long serialFirst = Long.MIN_VALUE;
 
 	/**
 	 * Adds a new event to the queue. Adding a new event to the queue preserves the temporal order of
@@ -41,17 +42,26 @@ public class EventQueue extends PriorityQueue<SimEvent> {
 	 * @param newEvent The event to be put in the queue.
 	 */
 	public void addEventFirst(SimEvent newEvent) {
-		newEvent.setSerial(0);
+		newEvent.setSerial(serialFirst++);
 		this.add(newEvent);
 	}
 
 	@Override
 	public SimEvent poll() {
-		if (!CloudSim.running()) {
-			return null;
-		}
-		return super.poll();
+		return !CloudSim.running() ? null : super.poll();
 	}
+
+	@Override
+	public SimEvent peek() {
+		return !CloudSim.running() ? null : super.peek();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return !CloudSim.running() || super.isEmpty();
+	}
+
+	// TODO: There might be other PriorityQueue methods that need to be overridden to check CloudSim::running
 
 	public void print() {
 		Iterator<SimEvent> iter = iterator();

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/SimEvent.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/SimEvent.java
@@ -110,19 +110,9 @@ public class SimEvent implements Cloneable, Comparable<SimEvent> {
 
 	@Override
 	public int compareTo(SimEvent event) {
-		if (event == null) {
-			return 1;
-		} else if (time < event.time) {
-			return -1;
-		} else if (time > event.time) {
-			return 1;
-		} else if (serial < event.serial) {
-			return -1;
-		} else if (this == event) {
-			return 0;
-		} else {
-			return 1;
-		}
+		var time_comp = Double.compare(this.time, event.time);
+		if (time_comp != 0) return time_comp;
+		return Long.compare(this.serial, event.serial);
 	}
 
 	/**

--- a/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/CloudsimTest.java
+++ b/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/CloudsimTest.java
@@ -1,0 +1,417 @@
+package org.cloudbus.cloudsim;
+
+import org.cloudbus.cloudsim.core.CloudActionTags;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.core.SimEvent;
+import org.cloudbus.cloudsim.core.predicates.Predicate;
+import org.cloudbus.cloudsim.util.DummyEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CloudsimTest {
+
+	private DummyEntity sender;
+	private DummyEntity receiver;
+
+	@BeforeEach
+	void setup() {
+		CloudSim.init(2, null, false, 0.1);
+		sender = new DummyEntity("Sender");
+		receiver = new DummyEntity("Receiver");
+	}
+
+	@Test
+	void testSimGet() {
+		assertEquals(2 + 2, CloudSim.getNumEntities());
+		assertTrue(CloudSim.getEntityList().containsAll(Arrays.asList(sender, receiver)));
+		assertNotNull(CloudSim.getSimulationCalendar());
+
+		assertEquals(sender, CloudSim.getEntity(sender.getId()));
+		assertEquals(sender, CloudSim.getEntity(sender.getName()));
+		assertEquals(sender.getId(), CloudSim.getEntityId(sender.getName()));
+		assertEquals(sender.getName(), CloudSim.getEntityName(sender.getId()));
+		assertEquals(sender.getName(), CloudSim.getEntityName(Integer.valueOf(sender.getId())));
+
+		assertEquals(receiver, CloudSim.getEntity(receiver.getId()));
+		assertEquals(receiver, CloudSim.getEntity(receiver.getName()));
+		assertEquals(receiver.getId(), CloudSim.getEntityId(receiver.getName()));
+		assertEquals(receiver.getName(), CloudSim.getEntityName(receiver.getId()));
+		assertEquals(receiver.getName(), CloudSim.getEntityName(Integer.valueOf(receiver.getId())));
+
+		assertThrows(IndexOutOfBoundsException.class, () -> CloudSim.getEntity(-1));
+		assertNull(CloudSim.getEntity("unknown"));
+		assertEquals(CloudSim.NOT_FOUND, CloudSim.getEntityId("unknown"));
+		assertNull(CloudSim.getEntityName(-1));
+		assertNull(CloudSim.getEntityName(Integer.valueOf(-1)));
+	}
+
+	@Test
+	void testSimAdd() {
+		CloudSim.runStart();
+
+		// This auto-registers.
+		final var dynamic = new DummyEntity("Dynamic");
+		dynamic.onStart = () -> dynamic.schedule(receiver.getId(), 5, null, "from dynamic");
+
+		final var last = CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+		assertEquals(5, last);
+	}
+
+	@Test
+	void testSimAddNull() {
+		assertThrows(NullPointerException.class, () -> CloudSim.addEntity(null));
+	}
+
+	@Test
+	void testScheduleSingleEvent() {
+		final var DATA = "Hello";
+		final var DELAY = 1.0;
+
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), DELAY, null, DATA);
+		};
+		final var last = CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+		assertEquals(DATA, receiver.receivedEvents().getFirst().data());
+		assertEquals(DELAY, last);
+	}
+
+	@Test
+	void testScheduleMultipleEventsInOrder() {
+		final var DATA_1 = "First";
+		final var DATA_2 = "Second";
+
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 2.0, null, DATA_2);
+			sender.schedule(receiver.getId(), 1.0, null, DATA_1);
+		};
+		CloudSim.run();
+
+		var received = receiver.receivedEvents();
+		assertEquals(2, received.size());
+		assertEquals(DATA_1, received.get(0).data());
+		assertEquals(DATA_2, received.get(1).data());
+	}
+
+	@Test
+	void testScheduleFirst() {
+		final var DATA_1 = "First";
+		final var DATA_2 = "Second";
+
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 1.0, null, DATA_2);
+			sender.scheduleFirst(receiver.getId(), 1.0, null, DATA_1);
+		};
+		CloudSim.run();
+
+		var received = receiver.receivedEvents();
+		assertEquals(2, received.size());
+		assertEquals(DATA_1, received.get(0).data());
+		assertEquals(DATA_2, received.get(1).data());
+	}
+
+
+	@Test
+	void testScheduleFirstNow() {
+		final var DATA_NOW = "Immediate";
+		final var DATA_LATER = "Later";
+
+		sender.onStart = () -> {
+			sender.scheduleNow(receiver.getId(), null, DATA_LATER);
+			sender.scheduleFirstNow(receiver.getId(), null, DATA_NOW);
+		};
+		CloudSim.run();
+
+		var received = receiver.receivedEvents();
+		assertEquals(2, received.size());
+		assertEquals(DATA_NOW, received.get(0).data());
+		assertEquals(DATA_LATER, received.get(1).data());
+	}
+
+	@Test
+	void testScheduleInvalid() {
+		double[] invalidDelays = {-1.0, Double.NEGATIVE_INFINITY, Double.MAX_VALUE, Double.POSITIVE_INFINITY};
+
+		for (double invalidDelay : invalidDelays) {
+			this.setup();
+			sender.onStart = () -> {
+				assertThrows(IllegalArgumentException.class, () -> sender.schedule(receiver.getId(), invalidDelay, null, "InvalidDelay"));
+			};
+			CloudSim.run();
+		}
+	}
+
+	@Test
+	void testScheduleFirstInvalid() {
+		double[] invalidDelays = {-1.0, Double.NEGATIVE_INFINITY, Double.MAX_VALUE, Double.POSITIVE_INFINITY};
+
+		for (double invalidDelay : invalidDelays) {
+			this.setup();
+			sender.onStart = () -> {
+				assertThrows(IllegalArgumentException.class, () -> sender.scheduleFirst(receiver.getId(), invalidDelay, null, "InvalidDelay"));
+			};
+			CloudSim.run();
+		}
+	}
+
+	@Test
+	void testEntityPause() {
+		final var EVENT_DELAY = 5;
+		final var RECEIVER_PAUSE = 10;
+
+		sender.onStart = () -> {
+			receiver.pause(RECEIVER_PAUSE);
+			sender.schedule(receiver.getId(), EVENT_DELAY, null, "delayed by pause");
+		};
+		final var last = CloudSim.run();
+		assertEquals(RECEIVER_PAUSE, receiver.receivedEvents().getFirst().time());
+		assertEquals(RECEIVER_PAUSE, last);
+	}
+
+	@Test
+	void testEntityCancelEvent() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 2, null, "delivered");
+			sender.schedule(receiver.getId(), 1, null, "canceled");
+			sender.cancelEvent(CloudSim.SIM_ANY);
+		};
+		final var last = CloudSim.run();
+		assertEquals(1, receiver.receivedEvents().size());
+		assertEquals(2, receiver.receivedEvents().getFirst().time());
+		assertEquals(2, last);
+	}
+
+	@Test
+	void testEntityCancelEventEmpty() {
+		sender.onStart = () -> {
+			sender.cancelEvent(CloudSim.SIM_ANY);
+			sender.schedule(receiver.getId(), 1, null, "delivered");
+			sender.schedule(receiver.getId(), 2, null, "delivered");
+		};
+		final var last = CloudSim.run();
+		assertEquals(2, receiver.receivedEvents().size());
+		assertEquals(2, last);
+	}
+
+
+	@Test
+	void testCancelAllEvent() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 2, null, "delivered");
+			sender.schedule(receiver.getId(), 1, null, "canceled");
+			CloudSim.cancelAll(sender.getId(), CloudSim.SIM_ANY);
+		};
+		final var last = CloudSim.run();
+		assertEquals(0, receiver.receivedEvents().size());
+		assertEquals(0, last);
+	}
+
+	@Test
+	void testCancelAllEventEmpty() {
+		sender.onStart = () -> {
+			CloudSim.cancelAll(sender.getId(), CloudSim.SIM_ANY);
+			sender.schedule(receiver.getId(), 1, null, "delivered");
+			sender.schedule(receiver.getId(), 2, null, "delivered");
+		};
+		final var last = CloudSim.run();
+		assertEquals(2, receiver.receivedEvents().size());
+		assertEquals(2, last);
+	}
+
+
+	@Test
+	void testEntityWaitFor() {
+		final var EVENT_DELAY_1 = 1;
+		final var EVENT_DELAY_2 = 2;
+		final var EVENT_DELAY_3 = 3;
+
+		sender.onStart = () -> {
+			receiver.waitForEvent(new Predicate() {
+				int counter = 0;
+
+				@Override
+				public boolean match(SimEvent event) {
+					counter += 1;
+					return counter == 2;
+				}
+			});
+			sender.schedule(receiver.getId(), EVENT_DELAY_1, null, "ignored");
+			sender.schedule(receiver.getId(), EVENT_DELAY_2, null, "wakes up");
+			sender.schedule(receiver.getId(), EVENT_DELAY_3, null, "standard");
+		};
+		final var last = CloudSim.run();
+		assertEquals(3, receiver.receivedEvents().size());
+		assertEquals(EVENT_DELAY_2, receiver.receivedEvents().get(0).time());
+		assertEquals(EVENT_DELAY_2, receiver.receivedEvents().get(1).time());
+		assertEquals(EVENT_DELAY_3, receiver.receivedEvents().get(2).time());
+		assertEquals(EVENT_DELAY_3, last);
+	}
+
+	@Test
+	void testSimPause() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 1, null, "before pause");
+			sender.schedule(receiver.getId(), 2, null, "after pause");
+
+			new Thread(() -> {
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					// ignore.
+				}
+				assertTrue(CloudSim.isPaused());
+				// Clock is 1 (instead of 0) because the sim loop runs the first event before checking for pauses.
+				assertEquals(1, CloudSim.clock());
+				CloudSim.resumeSimulation();
+			}).start();
+			CloudSim.pauseSimulation();
+		};
+		final var last = CloudSim.run();
+
+		assertEquals(2, receiver.receivedEvents().size());
+		assertEquals(2, last);
+	}
+
+	@Test
+	void testSimPauseAt() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 1, null, "before pause");
+			sender.schedule(receiver.getId(), 5, null, "after pause");
+
+			new Thread(() -> {
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					// ignore.
+				}
+				assertTrue(CloudSim.isPaused());
+				assertEquals(2, CloudSim.clock());
+				CloudSim.resumeSimulation();
+			}).start();
+			CloudSim.pauseSimulation(2);
+		};
+		final var last = CloudSim.run();
+
+		assertEquals(2, receiver.receivedEvents().size());
+		assertEquals(5, last);
+	}
+
+	@Test
+	void testSimTerminate() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 5, null, "ShouldNotBeDelivered");
+			sender.schedule(receiver.getId(), 10, null, "ShouldNotBeDelivered");
+
+			CloudSim.terminateSimulation();
+		};
+		final var last = CloudSim.run();
+
+		assertTrue(receiver.receivedEvents().isEmpty(), "No events should be received because the simulation was terminated");
+		assertEquals(0, last);
+
+		assertTrue(sender.shutdown);
+		assertTrue(receiver.shutdown);
+	}
+
+	@Test
+	void testSimTerminateAt() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 5, null, "ShouldNotBeDelivered");
+			sender.schedule(receiver.getId(), 10, null, "ShouldNotBeDelivered");
+
+			CloudSim.terminateSimulation(2);
+		};
+		final var last = CloudSim.run();
+
+		assertTrue(receiver.receivedEvents().isEmpty(), "No events should be received because the simulation was terminated");
+		assertEquals(2, last);
+
+		assertTrue(sender.shutdown);
+		assertTrue(receiver.shutdown);
+	}
+
+	@Test
+	void testSimAbruptallyTerminate() {
+		sender.onStart = () -> {
+			sender.schedule(receiver.getId(), 5, null, "ShouldNotBeDelivered");
+			sender.schedule(receiver.getId(), 10, null, "ShouldNotBeDelivered");
+
+			// This will be ignored.
+			CloudSim.pauseSimulation(2);
+
+			// This will be ignored.
+			CloudSim.terminateSimulation(3);
+
+			// Will stop it after the next tick, so at clock = 5.
+			// But with no events delivered on that clock.
+			CloudSim.abruptallyTerminate();
+		};
+		final var last = CloudSim.run();
+
+		assertTrue(receiver.receivedEvents().isEmpty(), "No events should be received because simulation was terminated.");
+		assertEquals(5, last);
+
+		assertTrue(sender.shutdown);
+		assertTrue(receiver.shutdown);
+	}
+
+	@Test
+	void testSimAbruptallyTerminateThroughEventTag() {
+		sender.onStart = () -> {
+			sender.schedule(CloudSim.getEntityId("CloudSimShutdown"), 1, CloudActionTags.ABRUPT_END_OF_SIMULATION, null);
+			sender.schedule(receiver.getId(), 5, null, "ShouldNotBeDelivered");
+		};
+		final var last = CloudSim.run();
+
+		assertTrue(receiver.receivedEvents().isEmpty(), "No events should be received because simulation was terminated.");
+		assertEquals(5, last);
+
+		assertTrue(sender.shutdown);
+		assertTrue(receiver.shutdown);
+	}
+
+	@Test
+	void testSimAbruptallyTerminateThroughNoMoreUsers() {
+		sender.onStart = () -> {
+			sender.schedule(CloudSim.getEntityId("CloudSimShutdown"), 1, null, null);
+			receiver.schedule(CloudSim.getEntityId("CloudSimShutdown"), 1, null, null);
+			sender.schedule(receiver.getId(), 5, null, "ShouldNotBeDelivered");
+		};
+		final var last = CloudSim.run();
+
+		assertTrue(receiver.receivedEvents().isEmpty(), "No events should be received because simulation was terminated.");
+		assertEquals(5, last);
+
+		assertTrue(sender.shutdown);
+		assertTrue(receiver.shutdown);
+	}
+
+	@Test
+	void testScheduleWithInvalidDestination() {
+		sender.onStart = () -> {
+			sender.schedule(-99, 1.0, null, "InvalidTarget");
+		};
+		assertThrows(IndexOutOfBoundsException.class, CloudSim::run);
+	}
+
+	@Test
+	void testSendFirstConsistentOrder() {
+		sender.onStart = () -> {
+			sender.scheduleFirst(receiver.getId(), 5, null, "A");
+			sender.scheduleFirst(receiver.getId(), 5, null, "B");
+			sender.scheduleFirst(receiver.getId(), 5, null, "C");
+		};
+		final var last = CloudSim.run();
+
+		assertEquals("A", receiver.receivedEvents().get(0).data());
+		assertEquals("B", receiver.receivedEvents().get(1).data());
+		assertEquals("C", receiver.receivedEvents().get(2).data());
+	}
+}

--- a/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/PredicatesTest.java
+++ b/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/PredicatesTest.java
@@ -1,0 +1,126 @@
+package org.cloudbus.cloudsim;
+
+import org.cloudbus.cloudsim.core.CloudActionTags;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.core.predicates.*;
+import org.cloudbus.cloudsim.util.DummyEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PredicatesTest {
+
+	private DummyEntity sender;
+	private DummyEntity receiver;
+
+	@BeforeEach
+	void setup() {
+		CloudSim.init(2, Calendar.getInstance(), false);
+		sender = new DummyEntity("Sender");
+		receiver = new DummyEntity("Receiver");
+	}
+
+	@Test
+	void testPredicateFromPositive() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateFrom(sender.getId()));
+			sender.schedule(receiver.getId(), 1, null, "");
+		};
+		CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateFromNegative() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateFrom(CloudSim.getCloudInfoServiceEntityId()));
+			sender.schedule(receiver.getId(), 1, null, "");
+		};
+		CloudSim.run();
+
+		assertEquals(0, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateNone() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateNone());
+			sender.schedule(receiver.getId(), 1, null, "");
+		};
+		CloudSim.run();
+
+		assertEquals(0, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateNotFromPositive() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateNotFrom(CloudSim.getCloudInfoServiceEntityId()));
+			sender.schedule(receiver.getId(), 1, null, "");
+		};
+		CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateNotFromNegative() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateNotFrom(sender.getId()));
+			sender.schedule(receiver.getId(), 1, null, "");
+		};
+		CloudSim.run();
+
+		assertEquals(0, receiver.receivedEvents().size());
+	}
+
+
+	@Test
+	void testPredicateNotTypeNegative() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateNotType(CloudActionTags.CLOUDLET_CANCEL));
+			sender.schedule(receiver.getId(), 1, CloudActionTags.BLANK, "");
+		};
+		CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateNotTypePositive() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateNotType(CloudActionTags.BLANK));
+			sender.schedule(receiver.getId(), 1, CloudActionTags.BLANK, "");
+		};
+		CloudSim.run();
+
+		assertEquals(0, receiver.receivedEvents().size());
+	}
+
+
+	@Test
+	void testPredicateTypePositive() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateType(CloudActionTags.BLANK));
+			sender.schedule(receiver.getId(), 1, CloudActionTags.BLANK, "");
+		};
+		CloudSim.run();
+
+		assertEquals(1, receiver.receivedEvents().size());
+	}
+
+	@Test
+	void testPredicateTypeNegative() {
+		sender.onStart = () -> {
+			receiver.waitForEvent(new PredicateType(CloudActionTags.RETURN_STAT_LIST));
+			sender.schedule(receiver.getId(), 1, CloudActionTags.BLANK, "");
+		};
+		CloudSim.run();
+
+		assertEquals(0, receiver.receivedEvents().size());
+	}
+}

--- a/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/util/DummyEntity.java
+++ b/modules/cloudsim/src/test/java/org/cloudbus/cloudsim/util/DummyEntity.java
@@ -1,0 +1,46 @@
+package org.cloudbus.cloudsim.util;
+
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.core.SimEntity;
+import org.cloudbus.cloudsim.core.SimEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DummyEntity extends SimEntity {
+
+	private final List<TimedSimEvent> receivedEvents = new ArrayList<>();
+	public Runnable onStart;
+	public boolean shutdown = false;
+
+	public DummyEntity(String name) {
+		super(name);
+	}
+
+	@Override
+	public void startEntity() {
+		super.startEntity();
+		if (onStart != null) {
+			onStart.run();
+		}
+	}
+
+	@Override
+	public void processEvent(SimEvent ev) {
+		receivedEvents.add(new TimedSimEvent(ev.getData(), CloudSim.clock()));
+	}
+
+	public List<TimedSimEvent> receivedEvents() {
+		return receivedEvents;
+	}
+
+	@Override
+	public void shutdownEntity() {
+		super.shutdownEntity();
+		shutdown = true;
+	}
+
+	public record TimedSimEvent(Object data, double time) {
+		//
+	}
+}


### PR DESCRIPTION
Comprehensive unit tests were added for the `core` package.
Several bugs were identified and fixed during testing, mainly addressing subtle concurrency issues and unexpected global state that could lead to inconsistent behavior or crashes.

### Key Fixes
- **EventQueue running flag**  
  Previously, `EventQueue` only partially checked the running flag, which could cause inconsistent state or simulation crashes.  
  Fixed by adding overloads to ensure no invalid states occur (not exhaustive).

- **Event serial numbering**  
  Serial numbers started from `0`. After calling `schedule` (adding an event with priority 0), a subsequent `scheduleNow` (also priority 0) could incorrectly insert as the second event.  
  Fixed by introducing a separate serial counter for scheduleNow.

- **Incomplete simulation reset**  
  `CloudSim::init` did not fully reset the simulation state—specifically, the variables `pause`, `pauseAt`, `abruptTerminate`, and `terminateAt` retained previous values.  
  Fixed by resetting them to their defaults.

- **Unsynchronized access to `CloudSim.paused`**  
  Access to `CloudSim.paused` was not synchronized, even though examples showed it being written to from separate threads.  
  Fixed by replacing the polling approach with `Object::wait()` and `Object::notify()` for thread-safe synchronization.

### Additional Notes
- Rewrote `CloudSim::getSimulationCalendar` for clarity.
- Did not test the `SimEntity::send` family since `NetworkTopology` is not part of the `core` package.
