### PR TITLE
Object ID Auto-Generation and Constructor Overloads

### DIFF
--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample1.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample1.java
@@ -9,30 +9,17 @@ package org.cloudbus.cloudsim.examples;
  * Copyright (c) 2009, The University of Melbourne, Australia
  */
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 /**
  * A simple example showing how to create a data center with one host and run one cloudlet on it.
@@ -86,7 +73,7 @@ public class CloudSimExample1 {
 			Datacenter datacenter0 = createDatacenter("Datacenter_0");
 
 			// Third step: Create Broker
-			broker = new DatacenterBroker("Broker");;
+			broker = new DatacenterBroker("Broker");
 			int brokerId = broker.getId();
 
 			// Fourth step: Create one virtual machine
@@ -169,18 +156,16 @@ public class CloudSimExample1 {
 		int mips = 1000;
 
 		// 3. Create PEs and add these into a list.
-		peList.add(new Pe(0, new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
+		peList.add(new Pe(new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
 
 		// 4. Create Host with its id and list of PEs and add them to the list
 		// of machines
-		int hostId = 0;
 		int ram = 2048; // host memory (MB)
 		long storage = 1000000; // host storage
 		int bw = 10000;
 
 		hostList.add(
 			new Host(
-				hostId,
 				new RamProvisionerSimple(ram),
 				new BwProvisionerSimple(bw),
 				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample2.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample2.java
@@ -10,30 +10,17 @@
 package org.cloudbus.cloudsim.examples;
 
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 
 /**
@@ -75,14 +62,13 @@ public class CloudSimExample2 {
 	            	Datacenter datacenter0 = createDatacenter("Datacenter_0");
 
 	            	//Third step: Create Broker
-	            	broker = new DatacenterBroker("Broker");;
-	            	int brokerId = broker.getId();
+				broker = new DatacenterBroker("Broker");
+				int brokerId = broker.getId();
 
 	            	//Fourth step: Create one virtual machine
 	            	vmlist = new ArrayList<>();
 
 	            	//VM description
-	            	int vmid = 0;
 	            	int mips = 250;
 	            	long size = 10000; //image size (MB)
 	            	int ram = 512; //vm memory (MB)
@@ -91,10 +77,8 @@ public class CloudSimExample2 {
 	            	String vmm = "Xen"; //VMM name
 
 	            	//create two VMs
-	            	Vm vm1 = new Vm(vmid, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
-
-	            	vmid++;
-	            	Vm vm2 = new Vm(vmid, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+				Vm vm1 = new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+				Vm vm2 = new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 
 	            	//add the VMs to the vmList
 	            	vmlist.add(vm1);
@@ -103,23 +87,20 @@ public class CloudSimExample2 {
 	            	//submit vm list to the broker
 	            	broker.submitGuestList(vmlist);
 
-
 	            	//Fifth step: Create two Cloudlets
 	            	cloudletList = new ArrayList<>();
 
 	            	//Cloudlet properties
-	            	int id = 0;
 	            	pesNumber=1;
 	            	long length = 250000;
 	            	long fileSize = 300;
 	            	long outputSize = 300;
 	            	UtilizationModel utilizationModel = new UtilizationModelFull();
 
-	            	Cloudlet cloudlet1 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+				Cloudlet cloudlet1 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 	            	cloudlet1.setUserId(brokerId);
 
-	            	id++;
-	            	Cloudlet cloudlet2 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+				Cloudlet cloudlet2 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 	            	cloudlet2.setUserId(brokerId);
 
 	            	//add the cloudlets to the list
@@ -168,17 +149,15 @@ public class CloudSimExample2 {
 	    	int mips = 1000;
 
 	        // 3. Create PEs and add these into a list.
-	    	peList.add(new Pe(0, new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
+			peList.add(new Pe(new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
 
 	        //4. Create Host with its id and list of PEs and add them to the list of machines
-	        int hostId=0;
 	        int ram = 2048; //host memory (MB)
 	        long storage = 1000000; //host storage
 	        int bw = 10000;
 
 	        hostList.add(
 	    			new Host(
-	    				hostId,
 	    				new RamProvisionerSimple(ram),
 	    				new BwProvisionerSimple(bw),
 	    				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample3.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample3.java
@@ -9,30 +9,17 @@
 
 package org.cloudbus.cloudsim.examples;
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 
 /**
@@ -82,7 +69,6 @@ public class CloudSimExample3 {
 			vmlist = new ArrayList<>();
 
 			//VM description
-			int vmid = 0;
 			int mips = 250;
 			long size = 10000; //image size (MB)
 			int ram = 2048; //vm memory (MB)
@@ -91,11 +77,9 @@ public class CloudSimExample3 {
 			String vmm = "Xen"; //VMM name
 
 			//create two VMs
-			Vm vm1 = new Vm(vmid, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
-
+			Vm vm1 = new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 			//the second VM will have twice the priority of VM1 and so will receive twice CPU time
-			vmid++;
-			Vm vm2 = new Vm(vmid, brokerId, mips * 2, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+			Vm vm2 = new Vm(brokerId, mips * 2, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 
 			//add the VMs to the vmList
 			vmlist.add(vm1);
@@ -109,17 +93,15 @@ public class CloudSimExample3 {
 			cloudletList = new ArrayList<>();
 
 			//Cloudlet properties
-			int id = 0;
 			long length = 40000;
 			long fileSize = 300;
 			long outputSize = 300;
 			UtilizationModel utilizationModel = new UtilizationModelFull();
 
-			Cloudlet cloudlet1 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet1 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet1.setUserId(brokerId);
 
-			id++;
-			Cloudlet cloudlet2 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet2 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet2.setUserId(brokerId);
 
 			//add the cloudlets to the list
@@ -171,14 +153,12 @@ public class CloudSimExample3 {
 		peList.add(new Pe(0, new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
 
 		//4. Create Hosts with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 2048; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
 
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,
@@ -190,13 +170,10 @@ public class CloudSimExample3 {
 		//create another machine in the Data center
 		List<Pe> peList2 = new ArrayList<>();
 
-		peList2.add(new Pe(0, new PeProvisionerSimple(mips)));
-
-		hostId++;
+		peList2.add(new Pe(new PeProvisionerSimple(mips)));
 
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample4.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample4.java
@@ -9,30 +9,17 @@
 
 package org.cloudbus.cloudsim.examples;
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerSpaceShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 
 /**
@@ -79,7 +66,6 @@ public class CloudSimExample4 {
 			vmlist = new ArrayList<>();
 
 			//VM description
-			int vmid = 0;
 			int mips = 250;
 			long size = 10000; //image size (MB)
 			int ram = 512; //vm memory (MB)
@@ -88,10 +74,8 @@ public class CloudSimExample4 {
 			String vmm = "Xen"; //VMM name
 
 			//create two VMs
-			Vm vm1 = new Vm(vmid, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
-
-			vmid++;
-			Vm vm2 = new Vm(vmid, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+			Vm vm1 = new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+			Vm vm2 = new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 
 			//add the VMs to the vmList
 			vmlist.add(vm1);
@@ -105,17 +89,15 @@ public class CloudSimExample4 {
 			cloudletList = new ArrayList<>();
 
 			//Cloudlet properties
-			int id = 0;
 			long length = 40000;
 			long fileSize = 300;
 			long outputSize = 300;
 			UtilizationModel utilizationModel = new UtilizationModelFull();
 
-			Cloudlet cloudlet1 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet1 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet1.setUserId(brokerId);
 
-			id++;
-			Cloudlet cloudlet2 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet2 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet2.setUserId(brokerId);
 
 			//add the cloudlets to the list
@@ -164,20 +146,17 @@ public class CloudSimExample4 {
 		int mips = 1000;
 
 		// 3. Create PEs and add these into a list.
-		peList.add(new Pe(0, new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
+		peList.add(new Pe(new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
 
 		//4. Create Host with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 2048; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
-
 
 		//in this example, the VMAllocatonPolicy in use is SpaceShared. It means that only one VM
 		//is allowed to run on each Pe. As each Host has only one Pe, only one VM can run on each Host.
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample5.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample5.java
@@ -9,30 +9,17 @@
 
 package org.cloudbus.cloudsim.examples;
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerSpaceShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 
 /**
@@ -86,7 +73,6 @@ public class CloudSimExample5 {
 			vmlist2 = new ArrayList<>();
 
 			//VM description
-			int vmid = 0;
 			int mips = 250;
 			long size = 10000; //image size (MB)
 			int ram = 512; //vm memory (MB)
@@ -95,10 +81,10 @@ public class CloudSimExample5 {
 			String vmm = "Xen"; //VMM name
 
 			//create two VMs: the first one belongs to user1
-			Vm vm1 = new Vm(vmid, brokerId1, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+			Vm vm1 = new Vm(brokerId1, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 
 			//the second VM: this one belongs to user2
-			Vm vm2 = new Vm(vmid, brokerId2, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
+			Vm vm2 = new Vm(brokerId2, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared());
 
 			//add the VMs to the vmlists
 			vmlist1.add(vm1);
@@ -113,16 +99,15 @@ public class CloudSimExample5 {
 			cloudletList2 = new ArrayList<>();
 
 			//Cloudlet properties
-			int id = 0;
 			long length = 40000;
 			long fileSize = 300;
 			long outputSize = 300;
 			UtilizationModel utilizationModel = new UtilizationModelFull();
 
-			Cloudlet cloudlet1 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet1 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet1.setUserId(brokerId1);
 
-			Cloudlet cloudlet2 = new Cloudlet(id, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
+			Cloudlet cloudlet2 = new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel);
 			cloudlet2.setUserId(brokerId2);
 
 			//add the cloudlets to the lists: each cloudlet belongs to one user
@@ -170,20 +155,17 @@ public class CloudSimExample5 {
 		int mips=1000;
 
 		// 3. Create PEs and add these into a list.
-		peList.add(new Pe(0, new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
+		peList.add(new Pe(new PeProvisionerSimple(mips))); // need to store Pe id and MIPS Rating
 
 		//4. Create Host with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 2048; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
-
 
 		//in this example, the VMAllocatonPolicy in use is SpaceShared. It means that only one VM
 		//is allowed to run on each Pe. As each Host has only one Pe, only one VM can run on each Host.
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample6.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample6.java
@@ -10,30 +10,17 @@
 
 package org.cloudbus.cloudsim.examples;
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 /**
  * An example showing how to create
@@ -62,7 +49,7 @@ public class CloudSimExample6 {
 
 		//create VMs
 		for(int i=0;i<vms;i++){
-			list.add(new Vm(i, userId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared()));
+			list.add(new Vm(userId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared()));
 		}
 
 		return list;
@@ -81,7 +68,7 @@ public class CloudSimExample6 {
 		UtilizationModel utilizationModel = new UtilizationModelFull();
 
 		for(int i=0;i<cloudlets;i++){
-			list.add(new Cloudlet(i, length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel));
+			list.add(new Cloudlet(length, pesNumber, fileSize, outputSize, utilizationModel, utilizationModel, utilizationModel));
 			list.getLast().setUserId(userId);
 		}
 
@@ -113,7 +100,7 @@ public class CloudSimExample6 {
 			Datacenter datacenter1 = createDatacenter("Datacenter_1");
 
 			//Third step: Create Broker
-			broker = new DatacenterBroker("Broker");;
+			broker = new DatacenterBroker("Broker");
 			int brokerId = broker.getId();
 
 			//Fourth step: Create VMs and Cloudlets and send them to broker
@@ -170,14 +157,12 @@ public class CloudSimExample6 {
 		peList2.add(new Pe(1, new PeProvisionerSimple(mips)));
 
 		//4. Create Hosts with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 2048; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
 
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,
@@ -186,11 +171,8 @@ public class CloudSimExample6 {
     			)
     		); // This is our first machine
 
-		hostId++;
-
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,
@@ -203,7 +185,6 @@ public class CloudSimExample6 {
 		//To create a host with a space-shared allocation policy for PEs to VMs:
 		//hostList.add(
     	//		new Host(
-    	//			hostId,
     	//			new CpuProvisionerSimple(peList1),
     	//			new RamProvisionerSimple(ram),
     	//			new BwProvisionerSimple(bw),
@@ -215,7 +196,6 @@ public class CloudSimExample6 {
 		//To create a host with a oportunistic space-shared allocation policy for PEs to VMs:
 		//hostList.add(
     	//		new Host(
-    	//			hostId,
     	//			new CpuProvisionerSimple(peList1),
     	//			new RamProvisionerSimple(ram),
     	//			new BwProvisionerSimple(bw),

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample7.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample7.java
@@ -10,30 +10,17 @@
 
 package org.cloudbus.cloudsim.examples;
 
+import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
-import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
-import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
 
 /**
  * An example showing how to pause and resume the simulation,
@@ -222,14 +209,12 @@ public class CloudSimExample7 {
 		peList2.add(new Pe(1, new PeProvisionerSimple(mips)));
 
 		//4. Create Hosts with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 16384; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
 
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,
@@ -238,11 +223,8 @@ public class CloudSimExample7 {
     			)
     		); // This is our first machine
 
-		hostId++;
-
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample8.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample8.java
@@ -10,26 +10,7 @@
 
 package org.cloudbus.cloudsim.examples;
 
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.LinkedList;
-import java.util.List;
-
-import org.cloudbus.cloudsim.Cloudlet;
-import org.cloudbus.cloudsim.CloudletSchedulerTimeShared;
-import org.cloudbus.cloudsim.Datacenter;
-import org.cloudbus.cloudsim.DatacenterBroker;
-import org.cloudbus.cloudsim.DatacenterCharacteristics;
-import org.cloudbus.cloudsim.Host;
-import org.cloudbus.cloudsim.Log;
-import org.cloudbus.cloudsim.Pe;
-import org.cloudbus.cloudsim.Storage;
-import org.cloudbus.cloudsim.UtilizationModel;
-import org.cloudbus.cloudsim.UtilizationModelFull;
-import org.cloudbus.cloudsim.Vm;
-import org.cloudbus.cloudsim.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.VmSchedulerTimeShared;
+import org.cloudbus.cloudsim.*;
 import org.cloudbus.cloudsim.core.CloudSim;
 import org.cloudbus.cloudsim.core.CloudSimTags;
 import org.cloudbus.cloudsim.core.SimEntity;
@@ -37,6 +18,12 @@ import org.cloudbus.cloudsim.core.SimEvent;
 import org.cloudbus.cloudsim.provisioners.BwProvisionerSimple;
 import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
 import org.cloudbus.cloudsim.provisioners.RamProvisionerSimple;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * An example showing how to create simulation entities
@@ -185,14 +172,12 @@ public class CloudSimExample8 {
 		peList2.add(new Pe(1, new PeProvisionerSimple(mips)));
 
 		//4. Create Hosts with its id and list of PEs and add them to the list of machines
-		int hostId=0;
 		int ram = 16384; //host memory (MB)
 		long storage = 1000000; //host storage
 		int bw = 10000;
 
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,
@@ -201,11 +186,8 @@ public class CloudSimExample8 {
     			)
     		); // This is our first machine
 
-		hostId++;
-
 		hostList.add(
     			new Host(
-    				hostId,
     				new RamProvisionerSimple(ram),
     				new BwProvisionerSimple(bw),
     				storage,

--- a/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample9.java
+++ b/modules/cloudsim-examples/src/main/java/org/cloudbus/cloudsim/examples/CloudSimExample9.java
@@ -68,64 +68,57 @@ public class CloudSimExample9 {
 			String vmm = "Xen"; // VMM name
 
 			// create time-sharing VM
-			vmlist.add(new Vm(0, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared()));
+			vmlist.add(new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerTimeShared()));
 
 			// create space-sharing VM
-			vmlist.add(new Vm(1, brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerSpaceShared()));
+			vmlist.add(new Vm(brokerId, mips, pesNumber, ram, bw, size, vmm, new CloudletSchedulerSpaceShared()));
 
 			// submit vm list to the broker
 			broker.submitGuestList(vmlist);
 
-
 			cloudletList = new ArrayList<>();
 
 			// Cloudlet properties
-			int id = 0;
 			long fileSize = 300;
 			long outputSize = 300;
 			UtilizationModel utilizationModel = new UtilizationModelFull();
 
-			Cloudlet cloudlet1 = new Cloudlet(id, 10000, pesNumber, fileSize,
+			Cloudlet cloudlet1 = new Cloudlet(10000, pesNumber, fileSize,
                                         outputSize, utilizationModel, utilizationModel, 
                                         utilizationModel);
 			cloudlet1.setUserId(brokerId);
 			cloudlet1.setGuestId(0);
 			cloudletList.add(cloudlet1);
-			id++;
 
-			Cloudlet cloudlet2 = new Cloudlet(id, 100000, pesNumber, fileSize,
+			Cloudlet cloudlet2 = new Cloudlet(100000, pesNumber, fileSize,
 					outputSize, utilizationModel, utilizationModel,
 					utilizationModel);
 			cloudlet2.setUserId(brokerId);
 			cloudlet2.setGuestId(0);
 			cloudletList.add(cloudlet2);
-			id++;
 
-			Cloudlet cloudlet3 = new Cloudlet(id, 1000000, pesNumber, fileSize,
+			Cloudlet cloudlet3 = new Cloudlet(1000000, pesNumber, fileSize,
 					outputSize, utilizationModel, utilizationModel,
 					utilizationModel);
 			cloudlet3.setUserId(brokerId);
 			cloudlet3.setGuestId(0);
 			cloudletList.add(cloudlet3);
-			id++;
 
-			Cloudlet cloudlet4 = new Cloudlet(id, 10000, pesNumber, fileSize,
+			Cloudlet cloudlet4 = new Cloudlet(10000, pesNumber, fileSize,
 					outputSize, utilizationModel, utilizationModel,
 					utilizationModel);
 			cloudlet4.setUserId(brokerId);
 			cloudlet4.setGuestId(1);
 			cloudletList.add(cloudlet4);
-			id++;
 
-			Cloudlet cloudlet5 = new Cloudlet(id, 100000, pesNumber, fileSize,
+			Cloudlet cloudlet5 = new Cloudlet(100000, pesNumber, fileSize,
 					outputSize, utilizationModel, utilizationModel,
 					utilizationModel);
 			cloudlet5.setUserId(brokerId);
 			cloudlet5.setGuestId(1);
 			cloudletList.add(cloudlet5);
-			id++;
 
-			Cloudlet cloudlet6 = new Cloudlet(id, 1000000, pesNumber, fileSize,
+			Cloudlet cloudlet6 = new Cloudlet(1000000, pesNumber, fileSize,
 					outputSize, utilizationModel, utilizationModel,
 					utilizationModel);
 			cloudlet6.setUserId(brokerId);

--- a/modules/cloudsim-examples/src/test/java/org/cloudbus/cloudsim/examples/CloudSimExampleTest.java
+++ b/modules/cloudsim-examples/src/test/java/org/cloudbus/cloudsim/examples/CloudSimExampleTest.java
@@ -41,7 +41,7 @@ public class CloudSimExampleTest {
             assertEquals(Cloudlet.CloudletStatus.SUCCESS, cl.getStatus());
             switch (cl.getCloudletId()) {
                 case 0, 1 -> assertEquals(1000, cl.getActualCPUTime(), 0);
-                default -> fail("Unknown cloudlet id");
+				default -> fail("Unknown cloudlet id: " + cl.getCloudletId());
             }
         }
     }
@@ -85,8 +85,8 @@ public class CloudSimExampleTest {
         for (Cloudlet cl : CloudSimExample5.broker2.getCloudletReceivedList()) {
             assertEquals(Cloudlet.CloudletStatus.SUCCESS, cl.getStatus());
             switch (cl.getCloudletId()) {
-                case 0 -> assertEquals(160, cl.getActualCPUTime(), 0);
-                default -> fail("Unknown cloudlet id");
+				case 0, 1 -> assertEquals(160, cl.getActualCPUTime(), 0);
+				default -> fail("Unknown cloudlet id: " + cl.getCloudletId());
             }
         }
     }
@@ -110,7 +110,7 @@ public class CloudSimExampleTest {
         for (Cloudlet cl : CloudSimExample7.broker.getCloudletReceivedList()) {
             assertEquals(Cloudlet.CloudletStatus.SUCCESS, cl.getStatus());
             switch (cl.getCloudletId()) {
-                case 0,5,1,6,2,7,4,9,3,8 -> assertEquals(320, cl.getActualCPUTime(), 0.01);
+				case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 -> assertEquals(320, cl.getActualCPUTime(), 0.01);
                 default -> fail("Unknown cloudlet id");
             }
         }
@@ -125,7 +125,8 @@ public class CloudSimExampleTest {
         for (Cloudlet cl : clList) {
             assertEquals(Cloudlet.CloudletStatus.SUCCESS, cl.getStatus());
             switch (cl.getCloudletId()) {
-                case 0,5,1,6,2,7,4,9,3,8,101,106,103,108,100,105,102,107,104,109 -> assertEquals(320, cl.getActualCPUTime(), 0);
+				case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109 ->
+						assertEquals(320, cl.getActualCPUTime(), 0);
                 default -> fail("Unknown cloudlet id");
             }
         }

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Cloudlet.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Cloudlet.java
@@ -7,11 +7,12 @@
  */
 package org.cloudbus.cloudsim;
 
+import org.cloudbus.cloudsim.core.CloudSim;
+
 import java.text.DecimalFormat;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.cloudbus.cloudsim.core.CloudSim;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Cloudlet is a user activity to be deployed on a Cloud Resource. It stores, despite all the
@@ -57,6 +58,17 @@ public class Cloudlet {
         // @NOTE: Convert an int to enum with CloudletStatus.values[i] (mind the array bounds)
     }
 
+	/**
+	 * The highest id used either automatically or explicitly.
+	 */
+	protected static final AtomicInteger highestId = new AtomicInteger(-1);
+
+	/**
+	 * Initialize the global state.
+	 */
+	public static void initialize() {
+		highestId.set(-1);
+	}
 
     /**
      * The cloudlet ID.
@@ -270,6 +282,48 @@ public class Cloudlet {
         requiredFiles = new LinkedList<>();
     }
 
+	/**
+	 * Allocates a new Cloudlet object. The Cloudlet length, input and output
+	 * file sizes should be greater than or equal to 1. By default this
+	 * constructor sets the history of this object.
+	 * CloudletID is auto-generated.
+	 *
+	 * @param cloudletLength      the length or size (in MI) of this cloudlet to be
+	 *                            executed in a PowerDatacenter
+	 * @param cloudletFileSize    the file size (in byte) of this cloudlet
+	 *                            <tt>BEFORE</tt> submitting to a Datacenter
+	 * @param cloudletOutputSize  the file size (in byte) of this cloudlet
+	 *                            <tt>AFTER</tt> finish executing by a Datacenter
+	 * @param pesNumber           the pes number
+	 * @param utilizationModelCpu the utilization model of cpu
+	 * @param utilizationModelRam the utilization model of ram
+	 * @param utilizationModelBw  the utilization model of bw
+	 * @pre cloudletID >= 0
+	 * @pre cloudletLength >= 0.0
+	 * @pre cloudletFileSize >= 1
+	 * @pre cloudletOutputSize >= 1
+	 * @post $none
+	 */
+	public Cloudlet(
+			final long cloudletLength,
+			final int pesNumber,
+			final long cloudletFileSize,
+			final long cloudletOutputSize,
+			final UtilizationModel utilizationModelCpu,
+			final UtilizationModel utilizationModelRam,
+			final UtilizationModel utilizationModelBw) {
+		this(
+				highestId.incrementAndGet(),
+				cloudletLength,
+				pesNumber,
+				cloudletFileSize,
+				cloudletOutputSize,
+				utilizationModelCpu,
+				utilizationModelRam,
+				utilizationModelBw
+		);
+    }
+
     /**
      * Allocates a new Cloudlet object. The Cloudlet length, input and output
      * file sizes should be greater than or equal to 1.
@@ -319,6 +373,53 @@ public class Cloudlet {
         costPerBw = 0.0;
 
         requiredFiles = fileList;
+    }
+
+	/**
+	 * Allocates a new Cloudlet object. The Cloudlet length, input and output
+	 * file sizes should be greater than or equal to 1.
+	 * CloudletID is auto-generated.
+	 *
+	 * @param cloudletLength      the length or size (in MI) of this cloudlet to be
+	 *                            executed in a PowerDatacenter
+	 * @param cloudletFileSize    the file size (in byte) of this cloudlet
+	 *                            <tt>BEFORE</tt> submitting to a PowerDatacenter
+	 * @param cloudletOutputSize  the file size (in byte) of this cloudlet
+	 *                            <tt>AFTER</tt> finish executing by a PowerDatacenter
+	 * @param record              record the history of this object or not
+	 * @param fileList            list of files required by this cloudlet
+	 * @param pesNumber           the pes number
+	 * @param utilizationModelCpu the utilization model of cpu
+	 * @param utilizationModelRam the utilization model of ram
+	 * @param utilizationModelBw  the utilization model of bw
+	 * @pre cloudletID >= 0
+	 * @pre cloudletLength >= 0.0
+	 * @pre cloudletFileSize >= 1
+	 * @pre cloudletOutputSize >= 1
+	 * @post $none
+	 */
+	public Cloudlet(
+			final long cloudletLength,
+			final int pesNumber,
+			final long cloudletFileSize,
+			final long cloudletOutputSize,
+			final UtilizationModel utilizationModelCpu,
+			final UtilizationModel utilizationModelRam,
+			final UtilizationModel utilizationModelBw,
+			final boolean record,
+			final List<String> fileList) {
+		this(
+				highestId.incrementAndGet(),
+				cloudletLength,
+				pesNumber,
+				cloudletFileSize,
+				cloudletOutputSize,
+				utilizationModelCpu,
+				utilizationModelRam,
+				utilizationModelBw,
+				record,
+				fileList
+		);
     }
 
     /**
@@ -371,6 +472,52 @@ public class Cloudlet {
         requiredFiles = fileList;
     }
 
+
+	/**
+	 * Allocates a new Cloudlet object. The Cloudlet length, input and output
+	 * file sizes should be greater than or equal to 1.
+	 * By default this constructor sets the history of this object.
+	 * CloudletID is auto-generated.
+	 *
+	 * @param cloudletLength      the length or size (in MI) of this cloudlet to be
+	 *                            executed in a PowerDatacenter
+	 * @param cloudletFileSize    the file size (in byte) of this cloudlet
+	 *                            <tt>BEFORE</tt> submitting to a PowerDatacenter
+	 * @param cloudletOutputSize  the file size (in byte) of this cloudlet
+	 *                            <tt>AFTER</tt> finish executing by a PowerDatacenter
+	 * @param fileList            list of files required by this cloudlet
+	 * @param pesNumber           the pes number
+	 * @param utilizationModelCpu the utilization model of cpu
+	 * @param utilizationModelRam the utilization model of ram
+	 * @param utilizationModelBw  the utilization model of bw
+	 * @pre cloudletID >= 0
+	 * @pre cloudletLength >= 0.0
+	 * @pre cloudletFileSize >= 1
+	 * @pre cloudletOutputSize >= 1
+	 * @post $none
+	 */
+	public Cloudlet(
+			final long cloudletLength,
+			final int pesNumber,
+			final long cloudletFileSize,
+			final long cloudletOutputSize,
+			final UtilizationModel utilizationModelCpu,
+			final UtilizationModel utilizationModelRam,
+			final UtilizationModel utilizationModelBw,
+			final List<String> fileList) {
+		this(
+				highestId.incrementAndGet(),
+				cloudletLength,
+				pesNumber,
+				cloudletFileSize,
+				cloudletOutputSize,
+				utilizationModelCpu,
+				utilizationModelRam,
+				utilizationModelBw,
+				fileList
+		);
+    }
+
     /**
      * Allocates a new Cloudlet object. The Cloudlet length, input and output
      * file sizes should be greater than or equal to 1.
@@ -406,6 +553,7 @@ public class Cloudlet {
         userId = -1;          // to be set by a Broker or user
         status = CloudletStatus.CREATED;
         this.cloudletId = cloudletId;
+		highestId.getAndUpdate(x -> Math.max(cloudletId, x));
         numberOfPes = pesNumber;
 
         execStartTime = 0.0;
@@ -435,6 +583,41 @@ public class Cloudlet {
         setUtilizationModelBw(utilizationModelBw);
         updateUid();
     }
+
+	/**
+	 * Allocates a new Cloudlet object. The Cloudlet length, input and output
+	 * file sizes should be greater than or equal to 1.
+	 * CloudletID is auto-generated.
+	 *
+	 * @param cloudletLength      the length or size (in MI) of this cloudlet to be
+	 *                            executed in a PowerDatacenter
+	 * @param cloudletFileSize    the file size (in byte) of this cloudlet
+	 *                            <tt>BEFORE</tt> submitting to a PowerDatacenter
+	 * @param cloudletOutputSize  the file size (in byte) of this cloudlet
+	 *                            <tt>AFTER</tt> finish executing by a PowerDatacenter
+	 * @param record              record the history of this object or not
+	 * @param pesNumber           the pes number
+	 * @param utilizationModelCpu the utilization model of cpu
+	 * @param utilizationModelRam the utilization model of ram
+	 * @param utilizationModelBw  the utilization model of bw
+	 * @pre cloudletID >= 0
+	 * @pre cloudletLength >= 0.0
+	 * @pre cloudletFileSize >= 1
+	 * @pre cloudletOutputSize >= 1
+	 * @post $none
+	 */
+	public Cloudlet(
+			final long cloudletLength,
+			final int pesNumber,
+			final long cloudletFileSize,
+			final long cloudletOutputSize,
+			final UtilizationModel utilizationModelCpu,
+			final UtilizationModel utilizationModelRam,
+			final UtilizationModel utilizationModelBw,
+			final boolean record) {
+		this(highestId.incrementAndGet(), cloudletLength, pesNumber, cloudletFileSize, cloudletOutputSize, utilizationModelCpu, utilizationModelRam, utilizationModelBw, record);
+    }
+
 
     /** Backward compatibility with ResCloudlet class in CloudSim6G */
     @Deprecated

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Host.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Host.java
@@ -7,14 +7,15 @@
 
 package org.cloudbus.cloudsim;
 
-import java.util.*;
-
 import org.cloudbus.cloudsim.core.GuestEntity;
 import org.cloudbus.cloudsim.core.HostEntity;
 import org.cloudbus.cloudsim.core.VirtualEntity;
 import org.cloudbus.cloudsim.lists.PeList;
 import org.cloudbus.cloudsim.provisioners.BwProvisioner;
 import org.cloudbus.cloudsim.provisioners.RamProvisioner;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A Host is a Physical Machine (PM) inside a Datacenter. It is also called as a Server.
@@ -28,6 +29,18 @@ import org.cloudbus.cloudsim.provisioners.RamProvisioner;
  * @since CloudSim Toolkit 1.0
  */
 public class Host implements HostEntity {
+
+	/**
+	 * The highest id used either automatically or explicitly.
+	 */
+	protected static final AtomicInteger highestId = new AtomicInteger(-1);
+	
+	/**
+	 * Initialize the global state.
+	 */
+	public static void initialize() {
+		highestId.set(-1);
+	}
 
 	/** The id of the host. */
 	private int id;
@@ -90,6 +103,24 @@ public class Host implements HostEntity {
 		setFailed(false);
 
 		cachedVirtualizationOverhead = new HashMap<>();
+	}
+
+	/**
+	 * Instantiates a new host with automatic id generation.
+	 *
+	 * @param ramProvisioner the ram provisioner
+	 * @param bwProvisioner  the bw provisioner
+	 * @param storage        the storage capacity
+	 * @param peList         the host's PEs list
+	 * @param vmScheduler    the vm scheduler
+	 */
+	public Host(
+			RamProvisioner ramProvisioner,
+			BwProvisioner bwProvisioner,
+			long storage,
+			List<? extends Pe> peList,
+			VmScheduler vmScheduler) {
+		this(highestId.incrementAndGet(), ramProvisioner, bwProvisioner, storage, peList, vmScheduler);
 	}
 
 	/**
@@ -293,6 +324,7 @@ public class Host implements HostEntity {
 	 */
 	protected void setId(int id) {
 		this.id = id;
+		highestId.getAndUpdate(x -> Math.max(id, x));
 	}
 
 	/**

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/HostDynamicWorkload.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/HostDynamicWorkload.java
@@ -8,16 +8,16 @@
 
 package org.cloudbus.cloudsim;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.cloudbus.cloudsim.core.CloudSim;
 import org.cloudbus.cloudsim.core.GuestEntity;
 import org.cloudbus.cloudsim.core.VirtualEntity;
 import org.cloudbus.cloudsim.lists.PeList;
 import org.cloudbus.cloudsim.provisioners.BwProvisioner;
 import org.cloudbus.cloudsim.provisioners.RamProvisioner;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A host supporting dynamic workloads and performance degradation.
@@ -57,6 +57,24 @@ public class HostDynamicWorkload extends Host {
 		super(id, ramProvisioner, bwProvisioner, storage, peList, vmScheduler);
 		setUtilizationMips(0);
 		setPreviousUtilizationMips(0);
+	}
+
+	/**
+	 * Instantiates a new host with automatic id generation.
+	 *
+	 * @param ramProvisioner the ram provisioner
+	 * @param bwProvisioner  the bw provisioner
+	 * @param storage        the storage capacity
+	 * @param peList         the host's PEs list
+	 * @param vmScheduler    the VM scheduler
+	 */
+	public HostDynamicWorkload(
+			RamProvisioner ramProvisioner,
+			BwProvisioner bwProvisioner,
+			long storage,
+			List<? extends Pe> peList,
+			VmScheduler vmScheduler) {
+		this(highestId.incrementAndGet(), ramProvisioner, bwProvisioner, storage, peList, vmScheduler);
 	}
 
 	@Override

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Pe.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Pe.java
@@ -10,6 +10,8 @@ package org.cloudbus.cloudsim;
 
 import org.cloudbus.cloudsim.provisioners.PeProvisioner;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Pe (Processing Element) class represents a CPU core of a physical machine (PM),
  * defined in terms of Millions Instructions Per Second (MIPS) rating.<br/>
@@ -38,6 +40,18 @@ public class Pe {
      * failed because it belongs to a machine which is also failed.
      */
     public static final int FAILED = 3;
+
+	/**
+	 * The highest id used either automatically or explicitly.
+	 */
+	protected static final AtomicInteger highestId = new AtomicInteger(-1);
+
+	/**
+	 * Initialize the global state.
+	 */
+	public static void initialize() {
+		highestId.set(-1);
+	}
 
     /**
      * The Pe id.
@@ -71,14 +85,31 @@ public class Pe {
         status = FREE;
     }
 
-    /**
+	/**
+	 * Instantiates a new Pe object with automatic id generation.
+	 *
+	 * @param peProvisioner the pe provisioner
+	 * @pre peProvisioner != null
+	 * @post $none
+	 */
+	public Pe(PeProvisioner peProvisioner) {
+		this.id = highestId.incrementAndGet();
+		setPeProvisioner(peProvisioner);
+
+		// when created it should be set to FREE, i.e. available for use.
+		status = FREE;
+	}
+
+
+	/**
      * Sets the id.
      *
      * @param id the new id
      */
     protected void setId(int id) {
-        this.id = id;
-    }
+		this.id = id;
+		highestId.getAndUpdate(x -> Math.max(id, x));
+	}
 
     /**
      * Gets the id.

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Vm.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/Vm.java
@@ -17,6 +17,7 @@ import org.cloudbus.cloudsim.provisioners.RamProvisioner;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Represents a Virtual Machine (VM) that runs inside a Host, sharing a hostList with other VMs. It can have nested
@@ -29,6 +30,18 @@ import java.util.List;
  * @since CloudSim Toolkit 1.0
  */
 public class Vm implements VirtualEntity {
+
+	/**
+	 * The highest id used either automatically or explicitly.
+	 */
+	protected static final AtomicInteger highestId = new AtomicInteger(-1);
+
+	/**
+	 * Initialize the global state.
+	 */
+	public static void initialize() {
+		highestId.set(-1);
+	}
 
 	/** The VM unique id. */
 	private final int id;
@@ -124,7 +137,7 @@ public class Vm implements VirtualEntity {
 
 	/**
 	 * Creates a new Vm object.
-	 * 
+	 *
 	 * @param id unique ID of the VM
 	 * @param userId ID of the VM's owner
 	 * @param mips the mips
@@ -156,6 +169,8 @@ public class Vm implements VirtualEntity {
 			String vmm,
 			CloudletScheduler cloudletScheduler) {
 		this.id = id;
+		highestId.getAndUpdate(x -> Math.max(id, x));
+
 		setUserId(userId);
 		setUid(GuestEntity.getUid(userId, id));
 		setMips(mips);
@@ -223,13 +238,79 @@ public class Vm implements VirtualEntity {
 		if (containerBwProvisioner.getBw() > getBw()) {
 			throw new RuntimeException("bwProvisioner.bw > bw");
 		}
-		
+
 		setGuestScheduler(guestScheduler);
 
 		setPeList(peList);
 		setGuestRamProvisioner(containerRamProvisioner);
 		setGuestBwProvisioner(containerBwProvisioner);
 		setVirtualizationOverhead(0);
+	}
+
+	/**
+	 * Creates a new Vm object with automatic id generation
+	 * 
+	 * @param userId ID of the VM's owner
+	 * @param mips the mips
+	 * @param numberOfPes amount of CPUs
+	 * @param ram amount of ram
+	 * @param bw amount of bandwidth
+	 * @param size The size the VM image size (the amount of storage it will use, at least initially).
+	 * @param vmm virtual machine monitor
+	 * @param cloudletScheduler cloudletScheduler policy for cloudlets scheduling
+	 * @pre id >= 0
+	 * @pre userId >= 0
+	 * @pre size > 0
+	 * @pre ram > 0
+	 * @pre bw > 0
+	 * @pre cpus > 0
+	 * @pre priority >= 0
+	 * @pre cloudletScheduler != null
+	 * @post $none
+	 */
+	public Vm(
+			int userId,
+			double mips,
+			int numberOfPes,
+			int ram,
+			long bw,
+			long size,
+			String vmm,
+			CloudletScheduler cloudletScheduler) {
+		this(highestId.incrementAndGet(), userId, mips, numberOfPes, ram, bw, size, vmm, cloudletScheduler);
+	}
+
+	/**
+	 * Create a new VM object that is capable to host nested guest entities with automatic id generation
+	 *
+	 * @param userId
+	 * @param mips
+	 * @param numberOfPes
+	 * @param ram
+	 * @param bw
+	 * @param size
+	 * @param vmm
+	 * @param cloudletScheduler
+	 * @param guestScheduler
+	 * @param containerRamProvisioner
+	 * @param containerBwProvisioner
+	 * @param peList
+	 */
+	public Vm(
+			int userId,
+			double mips,
+			int numberOfPes,
+			int ram,
+			long bw,
+			long size,
+			String vmm,
+			CloudletScheduler cloudletScheduler,
+			VmScheduler guestScheduler,
+			RamProvisioner containerRamProvisioner,
+			BwProvisioner containerBwProvisioner,
+			List<? extends Pe> peList
+	) {
+		this(highestId.incrementAndGet(), userId, mips, numberOfPes, ram, bw, size, vmm, cloudletScheduler, guestScheduler, containerRamProvisioner, containerBwProvisioner, peList);
 	}
 
 	/**

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/Container.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/Container.java
@@ -7,19 +7,33 @@
 
 package org.cloudbus.cloudsim.container.core;
 
-import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.CloudletScheduler;
+import org.cloudbus.cloudsim.VmStateHistoryEntry;
 import org.cloudbus.cloudsim.core.GuestEntity;
 import org.cloudbus.cloudsim.core.HostEntity;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created by sareh on 9/07/15.
  * Modified by Remo Andreoli (March 2024)
  */
 public class Container implements GuestEntity {
+
+	/**
+	 * The highest id used either automatically or explicitly.
+	 */
+	protected static final AtomicInteger highestId = new AtomicInteger(-1);
+
+	/**
+	 * Initialize the global state.
+	 */
+	public static void initialize() {
+		highestId.set(-1);
+	}
 
     /** The id. */
     private final int id;
@@ -104,7 +118,8 @@ public class Container implements GuestEntity {
             String containerManager,
             CloudletScheduler containerCloudletScheduler) {
         this.id = id;
-        setUserId(userId);
+		highestId.getAndUpdate(x -> Math.max(id, x));
+		setUserId(userId);
         setUid(GuestEntity.getUid(userId, id));
         setMips(mips);
         setNumberOfPes(numberOfPes);
@@ -120,9 +135,33 @@ public class Container implements GuestEntity {
         setCurrentAllocatedRam(0);
         setCurrentAllocatedSize(0);
         setVirtualizationOverhead(0);
-    }
+	}
 
-    /**
+	/**
+	 * Creates a new Container object with automatic id generation.
+	 *
+	 * @param userId
+	 * @param mips
+	 * @param numberOfPes
+	 * @param ram
+	 * @param bw
+	 * @param size
+	 * @param containerManager
+	 * @param containerCloudletScheduler
+	 */
+	public Container(
+			int userId,
+			double mips,
+			int numberOfPes,
+			int ram,
+			long bw,
+			long size,
+			String containerManager,
+			CloudletScheduler containerCloudletScheduler) {
+		this(highestId.incrementAndGet(), userId, mips, numberOfPes, ram, bw, size, containerManager, containerCloudletScheduler);
+	}
+
+	/**
      * Updates the processing of cloudlets running on this Container.
      *
      * @param currentTime current simulation time

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/ContainerVm.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/ContainerVm.java
@@ -7,7 +7,9 @@
 
 package org.cloudbus.cloudsim.container.core;
 
-import org.cloudbus.cloudsim.*;
+import org.cloudbus.cloudsim.Pe;
+import org.cloudbus.cloudsim.Vm;
+import org.cloudbus.cloudsim.VmScheduler;
 import org.cloudbus.cloudsim.core.GuestEntity;
 import org.cloudbus.cloudsim.lists.PeList;
 import org.cloudbus.cloudsim.provisioners.BwProvisioner;
@@ -101,6 +103,35 @@ public class ContainerVm extends Vm {
         setGuestBwProvisioner(containerBwProvisioner);
     }
 
+	/**
+	 * Creates a new VMCharacteristics object with automatic id generation.
+	 *
+	 * @param userId
+	 * @param mips
+	 * @param ram
+	 * @param bw
+	 * @param size
+	 * @param vmm
+	 * @param containerScheduler
+	 * @param containerRamProvisioner
+	 * @param containerBwProvisioner
+	 * @param peList
+	 */
+
+	public ContainerVm(
+			int userId,
+			double mips,
+			int ram,
+			long bw,
+			long size,
+			String vmm,
+			VmScheduler containerScheduler,
+			RamProvisioner containerRamProvisioner,
+			BwProvisioner containerBwProvisioner,
+			List<? extends Pe> peList
+	) {
+		this(highestId.incrementAndGet(), userId, mips, ram, bw, size, vmm, containerScheduler, containerRamProvisioner, containerBwProvisioner, peList);
+	}
 
 
     /**

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/PowerContainer.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/PowerContainer.java
@@ -57,6 +57,33 @@ public class PowerContainer extends Container implements PowerGuestEntity {
         }
 
         /**
+		 * Instantiates a new power vm with automatic id generation.
+		 *
+		 * @param id                 the id
+		 * @param userId             the user id
+		 * @param mips               the mips
+		 * @param pesNumber          the pes number
+		 * @param ram                the ram
+		 * @param bw                 the bw
+		 * @param size               the size
+		 * @param vmm                the vmm
+		 * @param cloudletScheduler  the cloudlet scheduler
+		 * @param schedulingInterval the scheduling interval
+		 */
+		public PowerContainer(
+				final int userId,
+				final double mips,
+				final int pesNumber,
+				final int ram,
+				final long bw,
+				final long size,
+				final String vmm,
+				final CloudletScheduler cloudletScheduler,
+				final double schedulingInterval) {
+			this(highestId.incrementAndGet(), userId, mips, pesNumber, ram, bw, size, vmm, cloudletScheduler, schedulingInterval);
+		}
+
+	/**
          * Updates the processing of guest entities running on this VM.
          *
          * @param currentTime current simulation time

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/PowerContainerVm.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/container/core/PowerContainerVm.java
@@ -68,6 +68,33 @@ public class PowerContainerVm extends ContainerVm implements PowerGuestEntity {
         setSchedulingInterval(schedulingInterval);
     }
 
+	/**
+	 * Instantiates a new power vm with automatic id generation.
+	 *
+	 * @param userId             the user id
+	 * @param mips               the mips
+	 * @param ram                the ram
+	 * @param bw                 the bw
+	 * @param size               the size
+	 * @param vmm                the vmm
+	 * @param containerScheduler the cloudlet scheduler
+	 * @param schedulingInterval the scheduling interval
+	 */
+	public PowerContainerVm(
+			final int userId,
+			final double mips,
+			final int ram,
+			final long bw,
+			final long size,
+			final String vmm,
+			final VmScheduler containerScheduler,
+			final RamProvisioner containerRamProvisioner,
+			final BwProvisioner containerBwProvisioner,
+			List<? extends Pe> peList,
+			final double schedulingInterval) {
+		this(highestId.incrementAndGet(), userId, mips, ram, bw, size, vmm, containerScheduler, containerRamProvisioner, containerBwProvisioner, peList, schedulingInterval);
+	}
+
     /**
      * Updates the processing of cloudlets running on this VM.
      *

--- a/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/modules/cloudsim/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -8,7 +8,9 @@
 
 package org.cloudbus.cloudsim.core;
 
+import org.cloudbus.cloudsim.*;
 import org.cloudbus.cloudsim.Log;
+import org.cloudbus.cloudsim.container.core.Container;
 import org.cloudbus.cloudsim.core.predicates.Predicate;
 import org.cloudbus.cloudsim.core.predicates.PredicateAny;
 import org.cloudbus.cloudsim.core.predicates.PredicateNone;
@@ -336,6 +338,13 @@ public class CloudSim {
 		running = false;
 		pauseAt = -1;
 		paused = false;
+
+		// Also reset the auto-id counters to make assignment reset on a new call to CloudSim::init to mimic old behavior.
+		Cloudlet.initialize();
+		Host.initialize();
+		Pe.initialize();
+		Vm.initialize();
+		Container.initialize();
 	}
 
 	// The two standard predicates


### PR DESCRIPTION
This update introduces a parallel API that removes the need to manually specify IDs when creating:
Container, ContainerVm, PowerContainer, PowerContainerVm, Cloudlet, Host, HostDynamicWorkload, Pe, and Vm.

Each class family now maintains an internal atomic counter that increments when new instances are created.
If an instance is created manually with a provided ID, the counter updates to the maximum of the previous value and the given ID.

The CloudSimExample* examples have been updated to demonstrate the new API.

(Fixed merge conflicts with PR221)